### PR TITLE
Add short para to README file

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,11 @@
 This is the top level of the FreeBSD source directory.  This file
-was last revised on:
-$FreeBSD$
+was last revised on: $FreeBSD$
+
+*****************************************************************
+Please note that files in this directory may have been patched
+to add functionality not present in the original source. This is
+*not* an unmodified copy of the FreeBSD source.
+*****************************************************************
 
 For copyright information, please see the file COPYRIGHT in this
 directory (additional copyright information also exists for some


### PR DESCRIPTION
This isn't a "pure" FreeBSD source, despite the repo being titled "FreeBSD-src".  This has two effects - it misleads a little as to the actual content, and someone dabbling in the pfSense source may not realise this for a while and may waste time.

So it's useful to note it up front when the repo is first opened/read, even if it is very obvious to more experienced devs.

(Case in point - I just spent 2 hours trying to figure out why pf.conf syntax seemed to include tokens not documented in man pages or findable online. Quite possibly some other person may get similarly confused, it ought to be said in the ReadMe.....!)
