### PR TITLE
MFC: r315225

### DIFF
--- a/contrib/libarchive/libarchive/archive_random.c
+++ b/contrib/libarchive/libarchive/archive_random.c
@@ -222,7 +222,7 @@ arc4_stir(void)
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
 	 */
-	for (i = 0; i < 1024; i++)
+	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();
 	arc4_count = 1600000;
 }

--- a/lib/libc/gen/arc4random.c
+++ b/lib/libc/gen/arc4random.c
@@ -172,7 +172,7 @@ arc4_stir(void)
 	 * Discard early keystream, as per recommendations in:
 	 * "(Not So) Random Shuffles of RC4" by Ilya Mironov.
 	 */
-	for (i = 0; i < 1024; i++)
+	for (i = 0; i < 3072; i++)
 		(void)arc4_getbyte();
 	arc4_count = 1600000;
 }

--- a/sys/libkern/arc4random.c
+++ b/sys/libkern/arc4random.c
@@ -82,7 +82,7 @@ arc4_randomstir (void)
 	 * paper "Weaknesses in the Key Scheduling Algorithm of RC4"
 	 * by Fluher, Mantin, and Shamir.  (N = 256 in our case.)
 	 */
-	for (n = 0; n < 256*4; n++)
+	for (n = 0; n < 768*4; n++)
 		arc4_randbyte();
 	mtx_unlock(&arc4_mtx);
 }


### PR DESCRIPTION
Operation C.R - hackers.mu
As per Cryptographic Requirements published on wikileaks on March 2017, we discard more bytes (3072 byte)of the first keystream to reduce the possibility of non-random bytes.