### PR TITLE
Extra functionality added when killing states

### DIFF
--- a/sbin/pfctl/pf_print_state.c
+++ b/sbin/pfctl/pf_print_state.c
@@ -352,6 +352,8 @@ print_state(struct pfsync_state *s, int opts)
 		bcopy(&s->id, &id, sizeof(u_int64_t));
 		printf("   id: %016jx creatorid: %08x",
 		    (uintmax_t )be64toh(id), ntohl(s->creatorid));
+		printf("   gateway: ");
+		print_host(&s->rt_addr, 0, s->af, opts);
 		printf("\n");
 	}
 }

--- a/sbin/pfctl/pfctl.8
+++ b/sbin/pfctl/pfctl.8
@@ -35,7 +35,7 @@
 .Sh SYNOPSIS
 .Nm pfctl
 .Bk -words
-.Op Fl AdeghmNnOPqRrvz
+.Op Fl AdeghMmNnOPqRrvz
 .Op Fl a Ar anchor
 .Oo Fl D Ar macro Ns =
 .Ar value Oc
@@ -45,7 +45,7 @@
 .Op Fl K Ar host | network
 .Xo
 .Oo Fl k
-.Ar host | network | label | id
+.Ar host | network | label | id | gateway
 .Oc Xc
 .Op Fl o Ar level
 .Op Fl p Ar device
@@ -256,14 +256,15 @@ option may be specified, which will kill all the source tracking
 entries from the first host/network to the second.
 .It Xo
 .Fl k
-.Ar host | network | label | id
+.Ar host | network | label | id | gateway
 .Xc
 Kill all of the state entries matching the specified
 .Ar host ,
 .Ar network ,
 .Ar label ,
+.Ar id ,
 or
-.Ar id .
+.Ar gateway.
 .Pp
 For example, to kill all of the state entries originating from
 .Dq host :
@@ -317,6 +318,27 @@ To kill a state with ID 4823e84500000018 created from a backup
 firewall with hostid 00000002 use:
 .Pp
 .Dl # pfctl -k id -k 4823e84500000018/2
+.Pp
+It is also possible to kill states created from a rule with the route-to/reply-to
+parameter set to route the connection through a particular gateway.
+Note that rules routing via a the default routing table (not via a route-to
+rule) will have their rt_addr set as 0.0.0.0 or ::. To kill all states using
+a gateway of 192.168.0.1 use:
+.Pp
+.Dl # pfctl -k gateway -k 192.168.0.1
+.Pp
+A network prefix length can also be specified.
+To kill all states using a gateway in 192.168.0.0/24:
+.Pp
+.Dl # pfctl -k gateway -k 192.168.0.0/24
+.Pp
+.It Fl M
+Kill matching states in the opposite direction (on other interfaces) when killing states.
+This applies to states killed using the -k option and also will apply to the flush
+command when flushing states.  This is useful when an interface is specified when flushing states. Example:
+.Pp
+.Dl # pfctl -M -i interface -Fs
+.Pp
 .It Fl m
 Merge in explicitly given options without resetting those
 which are omitted.

--- a/sbin/pfctl/pfctl_parser.h
+++ b/sbin/pfctl/pfctl_parser.h
@@ -51,6 +51,7 @@
 #define PF_OPT_NUMERIC		0x1000
 #define PF_OPT_MERGE		0x2000
 #define PF_OPT_RECURSE		0x4000
+#define PF_OPT_KILLMATCH	0x8000
 
 #define PF_TH_ALL		0xFF
 

--- a/share/man/man4/pf.4
+++ b/share/man/man4/pf.4
@@ -338,6 +338,9 @@ structure from the state table.
 Remove matching entries from the state table.
 This ioctl returns the number of killed states in
 .Va psk_killed .
+The psk_flag can be set with PSK_FLAG_KILLMATCH to also look
+for and kill a matching state in the opposite direction for
+each state matching the original criteria.
 .Bd -literal
 struct pfioc_state_kill {
 	struct pf_state_cmp	psk_pfcmp;
@@ -345,8 +348,10 @@ struct pfioc_state_kill {
 	int			psk_proto;
 	struct pf_rule_addr	psk_src;
 	struct pf_rule_addr	psk_dst;
+	struct pf_rule_addr	psk_rt_addr;
 	char			psk_ifname[IFNAMSIZ];
 	char			psk_label[PF_RULE_LABEL_SIZE];
+	int			psk_flag;
 	u_int			psk_killed;
 };
 .Ed
@@ -358,8 +363,9 @@ but ignores the
 .Va psk_af ,
 .Va psk_proto ,
 .Va psk_src ,
+.Va psk_dst ,
 and
-.Va psk_dst
+.Va psk_rt_addr
 fields of the
 .Vt pfioc_state_kill
 structure.

--- a/sys/net/pfvar.h
+++ b/sys/net/pfvar.h
@@ -1309,10 +1309,14 @@ struct pfioc_state_kill {
 	int			psk_proto;
 	struct pf_rule_addr	psk_src;
 	struct pf_rule_addr	psk_dst;
+	struct pf_rule_addr	psk_rt_addr;
 	char			psk_ifname[IFNAMSIZ];
 	char			psk_label[PF_RULE_LABEL_SIZE];
+	int			psk_flag;
 	u_int			psk_killed;
 };
+
+#define PSK_FLAG_KILLMATCH	0x0001
 
 struct pfioc_schedule_kill {
 	int		numberkilled;


### PR DESCRIPTION
to be used in Bug #8555

Adds two new options into pfctl:
 -M 
which will attempt to find and kill a matching state in the opposite direction if it exits
 -k gateway -k <gatewayip>
which will find states set to route through a specific gateway and kill these states.  

Also, gateway will be shown in state information when printing states with extra verbosity.

When used in conjunction with each other it should allow you to kill states routing out a specific gateway when it goes offline along with all matching NAT states.  Only works for policy based routing rules, not where default gateway is set.  Can also be used with a interface flush states to kill LAN states when a WAN goes offline.

See Bug #8555 for corresponding patches which trigger a selective state kill on gateway failover.

Code has not been used outside of limited test environment.  Posting for review.