### PR TITLE
QLogic 10 Gigabit Ethernet driver. Issue #9891

### DIFF
--- a/sys/amd64/conf/pfSense
+++ b/sys/amd64/conf/pfSense
@@ -181,6 +181,7 @@ device  	mlx4		# Shared code module between IB and Ethernet
 device  	mlx4en		# Mellanox ConnectX HCA Ethernet
 device		mlx5		# Shared code module between IB and Ethernet
 device		mlx5en		# Mellanox ConnectX-4 and ConnectX-4 LX
+device		qlxgb		# QLogic 10 Gigabit Ethernet adapter driver
 
 # Enable Linux Kernel Programming Interface - required by mlx[45]
 options 	COMPAT_LINUXKPI


### PR DESCRIPTION
Redmine Issue: https://redmine.pfsense.org/issues/9891
Ready for review

Add support for [qlxgb](https://www.freebsd.org/cgi/man.cgi?query=qlxgb&sektion=4) driver
see https://forum.netgate.com/topic/139931/hp-qlogic-nc523sfp-driver-install-freebsd-11-pfsense-kernal-recompile