### PR TITLE
Add driver bnxt for Broadcom NetXtreme interfaces. Implements #9155

### DIFF
--- a/sys/amd64/conf/pfSense
+++ b/sys/amd64/conf/pfSense
@@ -181,6 +181,7 @@ device  	mlx4		# Shared code module between IB and Ethernet
 device  	mlx4en		# Mellanox ConnectX HCA Ethernet
 device		mlx5		# Shared code module between IB and Ethernet
 device		mlx5en		# Mellanox ConnectX-4 and ConnectX-4 LX
+device		bnxt		# Broadcom NetXtreme-C/NetXtreme-E Family Ethernet driver
 
 # Enable Linux Kernel Programming Interface - required by mlx[45]
 options 	COMPAT_LINUXKPI


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/9155
- [X] Ready for review