### PR TITLE
em(4): Always reinit interface when adding/removing VLAN

### DIFF
--- a/sys/dev/e1000/if_em.c
+++ b/sys/dev/e1000/if_em.c
@@ -4042,7 +4042,6 @@ em_if_needs_restart(if_ctx_t ctx __unused, enum iflib_restart_event event)
 {
 	switch (event) {
 	case IFLIB_RESTART_VLAN_CONFIG:
-		return (false);
 	default:
 		return (true);
 	}


### PR DESCRIPTION
PR based off of https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=240818