### PR TITLE
Set MAXVIFS 64 for multicast routing. Implements #10909

### DIFF
--- a/sys/netinet/ip_mroute.h
+++ b/sys/netinet/ip_mroute.h
@@ -74,7 +74,7 @@
 /*
  * Types and macros for handling bitmaps with one bit per virtual interface.
  */
-#define	MAXVIFS 32
+#define	MAXVIFS 64
 typedef u_long vifbitmap_t;
 typedef u_short vifi_t;		/* type of a vif index */
 #define ALL_VIFS (vifi_t)-1


### PR DESCRIPTION
- [X] Redmine Issue: https://redmine.pfsense.org/issues/10909
- [X] Ready for review

This will allow to use up to 64 interfaces for multicast routing in PIMD.

