### PR TITLE
Add ral(4) to arm64 images. Feature request #10934

### DIFF
--- a/sys/arm64/conf/pfSense
+++ b/sys/arm64/conf/pfSense
@@ -67,7 +67,7 @@ device		rsu
 device		rsufw
 device		run		# Ralink RT2700U/RT2800U/RT3000U USB 802.11agn
 device		runfw
-device    ral   # Ralink RT2500, RT2501, RT2600, RT2700, RT2800, RT3090 and RT3900E chipsets
+device		ral   # Ralink RT2500, RT2501, RT2600, RT2700, RT2800, RT3090 and RT3900E chipsets
 device		rue
 device		rtwn
 device		rtwnfw

--- a/sys/arm64/conf/pfSense
+++ b/sys/arm64/conf/pfSense
@@ -67,6 +67,7 @@ device		rsu
 device		rsufw
 device		run		# Ralink RT2700U/RT2800U/RT3000U USB 802.11agn
 device		runfw
+device    ral   # Ralink RT2500, RT2501, RT2600, RT2700, RT2800, RT3090 and RT3900E chipsets
 device		rue
 device		rtwn
 device		rtwnfw

--- a/sys/arm64/conf/pfSense
+++ b/sys/arm64/conf/pfSense
@@ -67,7 +67,7 @@ device		rsu
 device		rsufw
 device		run		# Ralink RT2700U/RT2800U/RT3000U USB 802.11agn
 device		runfw
-device		ral   # Ralink RT2500, RT2501, RT2600, RT2700, RT2800, RT3090 and RT3900E chipsets
+device		ral		# Ralink RT2500, RT2501, RT2600, RT2700, RT2800, RT3090 and RT3900E chipsets
 device		rue
 device		rtwn
 device		rtwnfw


### PR DESCRIPTION
- [x]  Redmine Issue: https://redmine.pfsense.org/issues/10934
- [x]  Ready for review

Cards based on this potentially work in the SG-2100. The RT3090 has been shown to.

